### PR TITLE
Improve grep module regexp to avoid partial match

### DIFF
--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -694,7 +694,7 @@ function claw::process_dependencies() {
       # with regular expression
       for directory in "${module_search_path[@]}"; do
         for ext in "${fortran_ext[@]}"; do
-          found_file=("$(grep -s -l -i "^ *MODULE *${module_name}" \
+          found_file=("$(grep -s -l -i "^ *MODULE *${module_name}[[:blank:]]*\$" \
             "${directory}"/*"${ext}" | grep -v ".*\\.claw\\..*")")
           if [[ ${#found_file[@]} -gt 1 ]]; then
             break
@@ -725,7 +725,7 @@ function claw::process_dependencies() {
         [[ "${module_name}" != "ieee_exceptions" ]] &&
         [[ "${module_name}" != "ieee_arithmetic" ]]; then
         claw::warning "$2" "-" "-" \
-          "only module file found for ${module_name}. Might be out-of-date..."
+          "only module file found for ${module_name} with dependency ${dep}. Might be out-of-date..."
       fi
       continue
     elif [[ ${source_mod_file_found} == true ]] &&

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -725,7 +725,7 @@ function claw::process_dependencies() {
         [[ "${module_name}" != "ieee_exceptions" ]] &&
         [[ "${module_name}" != "ieee_arithmetic" ]]; then
         claw::warning "$2" "-" "-" \
-          "only module file found for ${module_name} with dependency ${dep}. Might be out-of-date..."
+          "only module file found for ${module_name}. Might be out-of-date..."
       fi
       continue
     elif [[ ${source_mod_file_found} == true ]] &&


### PR DESCRIPTION
## Issue
In the `process_dependencies` function we may end up in infinite recursive calls if the requested dependency doesn't exist and if there is a module that is a substring of the requested dependency.

## Example
To illustrate the issue, let's  assume that :
- a module `io_utilities` depends on the module `netcdf`;
- the module `netcdf` doesn't exist in the current project or path;
- there is a module `netcdf_io` which dependent on `io_utilities`;

in that case, the current grep construction:
```
found_file=("$(grep -s -l -i "^ *MODULE *${module_name}" \
  "${directory}"/*"${ext}" | grep -v ".*\\.claw\\..*")")
```
will match `netcdf_io` and thus start to loop in an non-existent circular dependency, ending up in infinite recursive calls.

## Solution
The solution is to force a MODULE match until the end of the string (i.e. `$`).
